### PR TITLE
Add service block to enable brew services support for kubewall

### DIFF
--- a/Formula/kubewall.rb
+++ b/Formula/kubewall.rb
@@ -37,4 +37,28 @@ class Kubewall < Formula
   test do
     system "#{bin}/kubewall -v"
   end
+
+  def caveats
+    <<~EOS
+      You can run kubewall directly:
+        kubewall
+
+      Or optionally run it as a background service:
+        brew services start kubewall
+
+      To manage the service:
+        brew services stop kubewall
+        brew services restart kubewall
+
+      Service logs are available at:
+        #{var}/log/kubewall.log
+    EOS
+  end
+
+  service do
+    run [opt_bin/"kubewall","--no-open-browser"]
+    keep_alive true
+    log_path var/"log/kubewall.log"
+    error_log_path var/"log/kubewall.log"
+  end
 end


### PR DESCRIPTION
Enables brew services functionality for kubewall.
```
brew services start kubewall
brew services stop kubewall
brew services restart kubewall
```
